### PR TITLE
Minor fixes to state naming

### DIFF
--- a/sugarcubes/src/command.rs
+++ b/sugarcubes/src/command.rs
@@ -18,8 +18,8 @@ pub enum Command {
     // The transition to be added
     CreateTransition(FiniteAutomatonTransition),
 
-    // The state, its position, and transitions involving it
-    DeleteState(u32, Vec2, Vec<FiniteAutomatonTransition>),
+    // The state, its position, its name, and transitions involving it
+    DeleteState(u32, Vec2, String, Vec<FiniteAutomatonTransition>),
     // The transition to be deleted
     DeleteTransition(FiniteAutomatonTransition),
 }
@@ -36,7 +36,7 @@ impl Command {
             }
             Self::CreateTransition(transition) => fa.automaton.add_transition(transition),
 
-            Self::DeleteState(state, _, _) => states.remove_state(fa, state),
+            Self::DeleteState(state, _, _, _) => states.remove_state(fa, state),
             Self::DeleteTransition(transition) => fa.automaton.remove_transition(transition),
         }
     }
@@ -56,9 +56,11 @@ impl Command {
             Self::CreateState(state, _) => states.remove_state(fa, *state),
             Self::CreateTransition(transition) => fa.automaton.remove_transition(*transition),
 
-            Self::DeleteState(id, position, transitions) => {
+            Self::DeleteState(id, position, name, transitions) => {
+                // TODO: Remember name in the command so it can be undone
                 let succeeded = states.try_add_state_with_id(fa, *position, *id);
                 if succeeded {
+                    states.insert_name(*id, name.to_string());
                     for &transition in transitions {
                         fa.automaton.add_transition(transition)
                     }

--- a/sugarcubes/src/command.rs
+++ b/sugarcubes/src/command.rs
@@ -13,6 +13,9 @@ pub enum Command {
     // The state to be updated, and the new value of is_final
     SetFinal(u32, bool),
 
+    // The state's ID and its old and new names
+    SetStateName(u32, String, String),
+
     // The state's ID and position
     CreateState(u32, Vec2),
     // The transition to be added
@@ -26,18 +29,22 @@ pub enum Command {
 
 impl Command {
     pub fn execute(&self, fa: &mut FiniteAutomaton, states: &mut States) {
-        match *self {
-            Self::SetInitial(state, _) => fa.automaton.set_initial(state),
+        match self {
+            Self::SetInitial(state, _) => fa.automaton.set_initial(*state),
             Self::RemoveInitial(_) => fa.automaton.remove_initial(),
-            Self::SetFinal(state, value) => fa.automaton.set_final(state, value),
+            Self::SetFinal(state, value) => fa.automaton.set_final(*state, *value),
+
+            Self::SetStateName(state, _, new_name) => {
+                states.insert_name(*state, new_name.to_string())
+            }
 
             Self::CreateState(state, pos) => {
-                states.try_add_state_with_id(fa, pos, state);
+                states.try_add_state_with_id(fa, *pos, *state);
             }
-            Self::CreateTransition(transition) => fa.automaton.add_transition(transition),
+            Self::CreateTransition(transition) => fa.automaton.add_transition(*transition),
 
-            Self::DeleteState(state, _, _, _) => states.remove_state(fa, state),
-            Self::DeleteTransition(transition) => fa.automaton.remove_transition(transition),
+            Self::DeleteState(state, _, _, _) => states.remove_state(fa, *state),
+            Self::DeleteTransition(transition) => fa.automaton.remove_transition(*transition),
         }
     }
 
@@ -52,6 +59,10 @@ impl Command {
             }
             Self::RemoveInitial(state) => fa.automaton.set_initial(*state),
             Self::SetFinal(state, value) => fa.automaton.set_final(*state, !value),
+
+            Self::SetStateName(state, old_name, _) => {
+                states.insert_name(*state, old_name.to_string())
+            }
 
             Self::CreateState(state, _) => states.remove_state(fa, *state),
             Self::CreateTransition(transition) => fa.automaton.remove_transition(*transition),

--- a/sugarcubes/src/top_panel/context_menu.rs
+++ b/sugarcubes/src/top_panel/context_menu.rs
@@ -118,6 +118,7 @@ impl TopPanel {
                                 command = Some(Command::DeleteState(
                                     selected,
                                     *states.get_position(selected),
+                                    states.get_name(selected),
                                     fa.automaton
                                         .transitions_with(selected)
                                         .into_iter()

--- a/sugarcubes/src/top_panel/context_menu.rs
+++ b/sugarcubes/src/top_panel/context_menu.rs
@@ -108,6 +108,7 @@ impl TopPanel {
                                 self.set_name_input_window.open = true;
                                 self.set_name_input_window.input = states.get_name(selected);
                                 self.set_name_state_id = Some(selected);
+                                self.set_name_input_window.end_of_line = true;
                                 *selected_state = None;
                                 ui.memory().close_popup();
                             }

--- a/sugarcubes/src/top_panel/mod.rs
+++ b/sugarcubes/src/top_panel/mod.rs
@@ -153,7 +153,10 @@ impl TopPanel {
             }
 
             if self.set_name_input_window.open {
-                self.show_set_name_input_window(egui_ctx, states);
+                let set_name_input_command = self.show_set_name_input_window(egui_ctx, states);
+                if let Some(set_name_input_command) = set_name_input_command {
+                    command = Some(set_name_input_command);
+                }
             }
         });
 

--- a/sugarcubes/src/top_panel/set_name.rs
+++ b/sugarcubes/src/top_panel/set_name.rs
@@ -1,4 +1,4 @@
-use super::TopPanel;
+use super::{Command, TopPanel, TopPanelCommand};
 use crate::States;
 
 impl TopPanel {
@@ -6,19 +6,25 @@ impl TopPanel {
         &mut self,
         egui_ctx: &egui::CtxRef,
         states: &mut States,
-    ) {
+    ) -> Option<TopPanelCommand> {
+        let mut command = None;
         let (hit_ok, contains_mouse) = self.set_name_input_window.show(egui_ctx);
         self.contains_mouse |= contains_mouse;
 
         if hit_ok {
             self.set_name_input_window.open = false;
             if let Some(set_name_state_id) = self.set_name_state_id {
+                let old_name = states.get_name(set_name_state_id);
                 let new_name = if self.set_name_input_window.input.is_empty() {
                     States::default_name(set_name_state_id)
                 } else {
                     self.set_name_input_window.input.clone()
                 };
-                states.insert_name(set_name_state_id, new_name);
+                command = Some(TopPanelCommand::Command(Command::SetStateName(
+                    set_name_state_id,
+                    old_name,
+                    new_name,
+                )));
             }
         }
 
@@ -26,5 +32,7 @@ impl TopPanel {
             self.set_name_input_window.input.clear();
             self.set_name_state_id = None;
         }
+
+        command
     }
 }


### PR DESCRIPTION
- Ensure that state names are saved and restored by the commands subsystem
- Allow renaming to be undone and redone
- Move the cursor to the end of the name setting input when it is opened